### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "run mysonylive"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@ The Password checker project checks if the password that is given as input has e
 Based on output, the program will confirm if the password can be used for login or not.
 The project accesses a real time database using 'Have I been pwned' website's api for information and checking of passwords.
 Modifications can be done to improve the project and if you are not able to, then you can comment with the suggestion.
+Repl.it URL - [![Run on Repl.it](https://repl.it/badge/github/Sounakde/Password_checker)](https://repl.it/github/Sounakde/Password_checker)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).